### PR TITLE
fix deepgram websocket error

### DIFF
--- a/agents/ten_packages/extension/deepgram_asr_python/requirements.txt
+++ b/agents/ten_packages/extension/deepgram_asr_python/requirements.txt
@@ -1,1 +1,2 @@
 deepgram-sdk==3.7.5
+websockets==13.1


### PR DESCRIPTION
fix deepgram websocket error, https://github.com/deepgram/deepgram-python-sdk/issues/483