### PR TITLE
fix build agent and task comman for image booting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,21 @@ RUN apt-get clean && apt-get update && apt-get install -y --no-install-recommend
     python3-dev \
     jq vim \
     ca-certificates \
+    gcc \
     && apt-get clean && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*
 
 WORKDIR /app
 
-COPY --from=builder /app/agents/.release/ agents/
+COPY --from=builder /app/agents/ agents/
 COPY --from=builder /app/server/bin/api /app/server/bin/api
 COPY --from=builder /usr/local/lib /usr/local/lib
 COPY --from=builder /usr/lib/python3 /usr/lib/python3
+COPY --from=builder /usr/local/bin/ /usr/local/bin/
+COPY --from=builder /usr/local/ten_gn/ /usr/local/ten_gn/
+COPY --from=builder /usr/local/go/ /usr/local/go/
+
+ENV PATH=/usr/local/go/bin:/usr/local/ten_gn:$PATH
+
+ENV CGO_ENABLED=1
 
 EXPOSE 8080
-
-ENTRYPOINT ["/app/server/bin/api"]


### PR DESCRIPTION
Executable files and environments are missing from the Dockerfile file, causing it to fail to run.
And according to the readme, the startup method is the task command. So when building the image, remove the api executable to run the