### PR TITLE
Add LiteLLM - support for Sambanova, Vertex AI, Gemini, Anthropic, Bedrock (100+LLMs) 

### DIFF
--- a/agents/ten_packages/extension/openai_chatgpt_python/openai.py
+++ b/agents/ten_packages/extension/openai_chatgpt_python/openai.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 import random
 import requests
-from openai import AsyncOpenAI, AsyncAzureOpenAI
+import litellm
 from openai.types.chat.chat_completion import ChatCompletion
 
 from ten.async_ten_env import AsyncTenEnv
@@ -46,17 +46,6 @@ class OpenAIChatGPT:
     def __init__(self, ten_env: AsyncTenEnv, config: OpenAIChatGPTConfig):
         self.config = config
         ten_env.log_info(f"OpenAIChatGPT initialized with config: {config.api_key}")
-        if self.config.vendor == "azure":
-            self.client = AsyncAzureOpenAI(
-                api_key=config.api_key,
-                api_version=self.config.azure_api_version,
-                azure_endpoint=config.azure_endpoint,
-            )
-            ten_env.log_info(
-                f"Using Azure OpenAI with endpoint: {config.azure_endpoint}, api_version: {config.azure_api_version}"
-            )
-        else:
-            self.client = AsyncOpenAI(api_key=config.api_key, base_url=config.base_url)
         self.session = requests.Session()
         if config.proxy_url:
             proxies = {
@@ -69,7 +58,7 @@ class OpenAIChatGPT:
 
     async def get_chat_completions(self, messages, tools=None) -> ChatCompletion:
         req = {
-            "model": self.config.model,
+            "model": f"{self.config.vendor}/{self.config.model}",
             "messages": [
                 {
                     "role": "system",
@@ -87,7 +76,7 @@ class OpenAIChatGPT:
         }
 
         try:
-            response = await self.client.chat.completions.create(**req)
+            response = await litellm.acompletion(**req)
         except Exception as e:
             raise RuntimeError(f"CreateChatCompletion failed, err: {e}") from e
 
@@ -95,7 +84,7 @@ class OpenAIChatGPT:
 
     async def get_chat_completions_stream(self, messages, tools=None, listener=None):
         req = {
-            "model": self.config.model,
+            "model": f"{self.config.vendor}/{self.config.model}",
             "messages": [
                 {
                     "role": "system",
@@ -114,7 +103,7 @@ class OpenAIChatGPT:
         }
 
         try:
-            response = await self.client.chat.completions.create(**req)
+            response = await litellm.acompletion(**req)
         except Exception as e:
             raise RuntimeError(f"CreateChatCompletionStream failed, err: {e}") from e
 


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 

Example

```python
from litellm import completion
import os

## set ENV variables
os.environ["OPENAI_API_KEY"] = "your-openai-key"
os.environ["ANTHROPIC_API_KEY"] = "your-cohere-key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="openai/gpt-4o", messages=messages)

# anthropic call
response = completion(model="anthropic/claude-3-sonnet-20240229", messages=messages)
print(response)
```

### Response (OpenAI Format)

```json
{
    "id": "chatcmpl-565d891b-a42e-4c39-8d14-82a1f5208885",
    "created": 1734366691,
    "model": "claude-3-sonnet-20240229",
    "object": "chat.completion",
    "system_fingerprint": null,
    "choices": [
        {
            "finish_reason": "stop",
            "index": 0,
            "message": {
                "content": "Hello! As an AI language model, I don't have feelings, but I'm operating properly and ready to assist you with any questions or tasks you may have. How can I help you today?",
                "role": "assistant",
                "tool_calls": null,
                "function_call": null
            }
        }
    ],
    "usage": {
        "completion_tokens": 43,
        "prompt_tokens": 13,
        "total_tokens": 56,
        "completion_tokens_details": null,
        "prompt_tokens_details": {
            "audio_tokens": null,
            "cached_tokens": 0
        },
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0
    }
}
```
