### PR TITLE
fix: update lambda functions to include unused parameter

### DIFF
--- a/agents/ten_packages/extension/cartesia_tts/tests/test_basic.py
+++ b/agents/ten_packages/extension/cartesia_tts/tests/test_basic.py
@@ -22,7 +22,7 @@ class ExtensionTesterBasic(ExtensionTester):
         print("send hello_world")
         ten_env.send_cmd(
             new_cmd,
-            lambda ten_env, result: self.check_hello(ten_env, result),
+            lambda ten_env, result, _: self.check_hello(ten_env, result),
         )
 
         print("tester on_start_done")

--- a/agents/ten_packages/extension/cosy_tts_python/tests/test_basic.py
+++ b/agents/ten_packages/extension/cosy_tts_python/tests/test_basic.py
@@ -22,7 +22,7 @@ class ExtensionTesterBasic(ExtensionTester):
         print("send hello_world")
         ten_env.send_cmd(
             new_cmd,
-            lambda ten_env, result: self.check_hello(ten_env, result),
+            lambda ten_env, result, _: self.check_hello(ten_env, result),
         )
 
         print("tester on_start_done")

--- a/agents/ten_packages/extension/dify_python/tests/test_basic.py
+++ b/agents/ten_packages/extension/dify_python/tests/test_basic.py
@@ -22,7 +22,7 @@ class ExtensionTesterBasic(ExtensionTester):
         print("send hello_world")
         ten_env.send_cmd(
             new_cmd,
-            lambda ten_env, result: self.check_hello(ten_env, result),
+            lambda ten_env, result, _: self.check_hello(ten_env, result),
         )
 
         print("tester on_start_done")

--- a/agents/ten_packages/extension/elevenlabs_tts_python/tests/test_basic.py
+++ b/agents/ten_packages/extension/elevenlabs_tts_python/tests/test_basic.py
@@ -22,7 +22,7 @@ class ExtensionTesterBasic(ExtensionTester):
         print("send hello_world")
         ten_env.send_cmd(
             new_cmd,
-            lambda ten_env, result: self.check_hello(ten_env, result),
+            lambda ten_env, result,_: self.check_hello(ten_env, result),
         )
 
         print("tester on_start_done")

--- a/agents/ten_packages/extension/file_chunker/file_chunker_extension.py
+++ b/agents/ten_packages/extension/file_chunker/file_chunker_extension.py
@@ -84,7 +84,7 @@ class FileChunkerExtension(Extension):
         wait_event = threading.Event()
         ten.send_cmd(
             cmd_out,
-            lambda ten, result: wait_event.set(),
+            lambda ten, result, _: wait_event.set(),
         )
         if wait:
             wait_event.wait()
@@ -97,7 +97,7 @@ class FileChunkerExtension(Extension):
         cmd_out = Cmd.create("embed_batch")
         cmd_out.set_property_from_json("inputs", json.dumps(texts))
         ten.send_cmd(
-            cmd_out, lambda ten, result: self.vector_store(ten, path, texts, result)
+            cmd_out, lambda ten, result, _: self.vector_store(ten, path, texts, result)
         )
 
     def vector_store(self, ten: TenEnv, path: str, texts: List[str], result: CmdResult):
@@ -114,7 +114,7 @@ class FileChunkerExtension(Extension):
             content.append({"text": text, "embedding": embedding})
         cmd_out.set_property_string("content", json.dumps(content))
         # ten.log_info(json.dumps(content))
-        ten.send_cmd(cmd_out, lambda ten, result: self.file_chunked(ten, path))
+        ten.send_cmd(cmd_out, lambda ten, result, _: self.file_chunked(ten, path))
 
     def file_chunked(self, ten: TenEnv, path: str):
         if path in self.counters and path in self.expected:
@@ -137,7 +137,7 @@ class FileChunkerExtension(Extension):
                 cmd_out.set_property_string("collection", self.new_collection_name)
                 ten.send_cmd(
                     cmd_out,
-                    lambda ten, result: ten.log_info("send_cmd done"),
+                    lambda ten, result, _: ten.log_info("send_cmd done"),
                 )
                 self.file_chunked_event.set()
         else:

--- a/agents/ten_packages/extension/glue_python_async/tests/test_basic.py
+++ b/agents/ten_packages/extension/glue_python_async/tests/test_basic.py
@@ -22,7 +22,7 @@ class ExtensionTesterBasic(ExtensionTester):
         print("send hello_world")
         ten_env.send_cmd(
             new_cmd,
-            lambda ten_env, result: self.check_hello(ten_env, result),
+            lambda ten_env, result, _: self.check_hello(ten_env, result),
         )
 
         print("tester on_start_done")

--- a/agents/ten_packages/extension/http_server_python/http_server_extension.py
+++ b/agents/ten_packages/extension/http_server_python/http_server_extension.py
@@ -25,7 +25,7 @@ class HTTPHandler(BaseHTTPRequestHandler):
                 self.ten.log_info("incoming request %s", input_file)
                 self.ten.send_cmd(
                     Cmd.create_from_json(input_file),
-                    lambda ten, result: ten.log_info(
+                    lambda ten, result, _: ten.log_info(
                         "finish send_cmd from http server %s %s", input_file, result
                     ),
                 )

--- a/agents/ten_packages/extension/interrupt_detector_python/extension.py
+++ b/agents/ten_packages/extension/interrupt_detector_python/extension.py
@@ -52,7 +52,7 @@ class InterruptDetectorExtension(Extension):
         new_cmd.set_property_from_json(None, cmd_json)
         ten.send_cmd(
             new_cmd,
-            lambda ten, result: ten.log_info("send_cmd done"),
+            lambda ten, result, _: ten.log_info("send_cmd done"),
         )
 
         cmd_result = CmdResult.create(StatusCode.OK)

--- a/agents/ten_packages/extension/llama_index_chat_engine/llama_embedding.py
+++ b/agents/ten_packages/extension/llama_index_chat_engine/llama_embedding.py
@@ -39,7 +39,7 @@ class LlamaEmbedding(BaseEmbedding):
         wait_event = threading.Event()
         resp: List[float]
 
-        def callback(_, result):
+        def callback(_, result, __):
             nonlocal resp
             nonlocal wait_event
 

--- a/agents/ten_packages/extension/llama_index_chat_engine/llama_llm.py
+++ b/agents/ten_packages/extension/llama_index_chat_engine/llama_llm.py
@@ -59,7 +59,7 @@ class LlamaLLM(CustomLLM):
         resp: ChatResponse
         wait_event = threading.Event()
 
-        def callback(_, result):
+        def callback(_, result, __):
             self.ten.log_debug("LlamaLLM chat callback done")
             nonlocal resp
             nonlocal wait_event
@@ -71,7 +71,9 @@ class LlamaLLM(CustomLLM):
         cmd = Cmd.create("call_chat")
         cmd.set_property_string("messages", messages_str)
         cmd.set_property_bool("stream", False)
-        self.ten.log_info(f"LlamaLLM chat send_cmd {cmd.get_name()}, messages {messages_str}")
+        self.ten.log_info(
+            f"LlamaLLM chat send_cmd {cmd.get_name()}, messages {messages_str}"
+        )
 
         self.ten.send_cmd(cmd, callback)
         wait_event.wait()
@@ -103,7 +105,7 @@ class LlamaLLM(CustomLLM):
                     delta=delta_text,
                 )
 
-        def callback(_, result):
+        def callback(_, result, __):
             nonlocal cur_tokens
             nonlocal resp_queue
 

--- a/agents/ten_packages/extension/llama_index_chat_engine/llama_retriever.py
+++ b/agents/ten_packages/extension/llama_index_chat_engine/llama_retriever.py
@@ -63,7 +63,7 @@ class LlamaRetriever(BaseRetriever):
         wait_event = threading.Event()
         resp: List[NodeWithScore] = []
 
-        def cmd_callback(_, result):
+        def cmd_callback(_, result, __):
             nonlocal resp
             nonlocal wait_event
             resp = format_node_result(self.ten, result)

--- a/agents/ten_packages/extension/minimax_tts_python/tests/test_basic.py
+++ b/agents/ten_packages/extension/minimax_tts_python/tests/test_basic.py
@@ -22,7 +22,7 @@ class ExtensionTesterBasic(ExtensionTester):
         print("send hello_world")
         ten_env.send_cmd(
             new_cmd,
-            lambda ten_env, result: self.check_hello(ten_env, result),
+            lambda ten_env, result, _: self.check_hello(ten_env, result),
         )
 
         print("tester on_start_done")

--- a/agents/ten_packages/extension/qwen_llm_python/qwen_llm_extension.py
+++ b/agents/ten_packages/extension/qwen_llm_python/qwen_llm_extension.py
@@ -269,7 +269,7 @@ class QWenLLMExtension(Extension):
             cmd_out = Cmd.create("flush")
             ten.send_cmd(
                 cmd_out,
-                lambda ten, result: ten.log_info("send_cmd flush done"),
+                lambda ten, result, _: ten.log_info("send_cmd flush done"),
             )
         elif cmd_name == "call_chat":
             self.queue.put((cmd, ts))

--- a/agents/ten_packages/extension/vision_analyze_tool_python/tests/test_basic.py
+++ b/agents/ten_packages/extension/vision_analyze_tool_python/tests/test_basic.py
@@ -22,7 +22,7 @@ class ExtensionTesterBasic(ExtensionTester):
         print("send hello_world")
         ten_env.send_cmd(
             new_cmd,
-            lambda ten_env, result: self.check_hello(ten_env, result),
+            lambda ten_env, result, _: self.check_hello(ten_env, result),
         )
 
         print("tester on_start_done")

--- a/agents/ten_packages/extension/vision_tool_python/tests/test_basic.py
+++ b/agents/ten_packages/extension/vision_tool_python/tests/test_basic.py
@@ -22,7 +22,7 @@ class ExtensionTesterBasic(ExtensionTester):
         print("send hello_world")
         ten_env.send_cmd(
             new_cmd,
-            lambda ten_env, result: self.check_hello(ten_env, result),
+            lambda ten_env, result, _: self.check_hello(ten_env, result),
         )
 
         print("tester on_start_done")


### PR DESCRIPTION
This pull request includes several changes across multiple files to update the lambda function signatures used in various `send_cmd` method calls. The main change is the addition of an extra unused parameter to the lambda functions, ensuring consistency across the codebase.

Updates to lambda function signatures:

* [`agents/ten_packages/extension/cartesia_tts/tests/test_basic.py`](diffhunk://#diff-ca74f9d60e0dab97e6d5d42d931d890e15cdbfdd3db39201e3a3cda83543f7bfL25-R25): Updated lambda function in `on_start` method to include an extra unused parameter.
* [`agents/ten_packages/extension/file_chunker/file_chunker_extension.py`](diffhunk://#diff-2640e3df0782d6bc8e28706c29ab14a24d3b4238191dcf2718377567c1ab3648L87-R87): Updated lambda functions in `create_collection`, `embedding`, `vector_store`, and `file_chunked` methods to include an extra unused parameter. [[1]](diffhunk://#diff-2640e3df0782d6bc8e28706c29ab14a24d3b4238191dcf2718377567c1ab3648L87-R87) [[2]](diffhunk://#diff-2640e3df0782d6bc8e28706c29ab14a24d3b4238191dcf2718377567c1ab3648L100-R100) [[3]](diffhunk://#diff-2640e3df0782d6bc8e28706c29ab14a24d3b4238191dcf2718377567c1ab3648L117-R117) [[4]](diffhunk://#diff-2640e3df0782d6bc8e28706c29ab14a24d3b4238191dcf2718377567c1ab3648L140-R140)
* [`agents/ten_packages/extension/http_server_python/http_server_extension.py`](diffhunk://#diff-a5a4fac4ef8fff91c255f5acf470ca928e9ab4651f79a223d270caa1cebdd6d2L28-R28): Updated lambda function in `do_POST` method to include an extra unused parameter.
* [`agents/ten_packages/extension/llama_index_chat_engine/llama_llm.py`](diffhunk://#diff-0e8524c3d118cf1869dc3295ec1ca7bbd00a5cdd0d8f71fd516d188d69a686ecL62-R62): Updated lambda functions in `chat`, `callback`, and `gen` methods to include an extra unused parameter. [[1]](diffhunk://#diff-0e8524c3d118cf1869dc3295ec1ca7bbd00a5cdd0d8f71fd516d188d69a686ecL62-R62) [[2]](diffhunk://#diff-0e8524c3d118cf1869dc3295ec1ca7bbd00a5cdd0d8f71fd516d188d69a686ecL74-R76) [[3]](diffhunk://#diff-0e8524c3d118cf1869dc3295ec1ca7bbd00a5cdd0d8f71fd516d188d69a686ecL106-R108)